### PR TITLE
SLING-9601 Provide a Sling javax.activation bundle without dependencies built in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
                                 <Bundle-Name>
                                     ${project.name} (No embedded dependencies)
                                 </Bundle-Name>
-                                <Bundle-Version>
-                                    ${project.version}-nodeps
-                                </Bundle-Version>
+                                <Bundle-SymbolicName>
+                                    ${project.artifactId}.nodeps
+                                </Bundle-SymbolicName>
                                 <Bundle-Activator>org.apache.sling.javax.activation.internal.Activator</Bundle-Activator>
                             </instructions>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
-        <version>26</version>
+        <version>39</version>
         <relativePath/>
     </parent>
         
@@ -51,13 +51,35 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Bundle-Activator>org.apache.sling.javax.activation.internal.Activator</Bundle-Activator>
-                        <Export-Package>javax.activation;version=${javax.activation.version}</Export-Package>
-                        <Embed-Dependency>*;scope=compile</Embed-Dependency>
-                    </instructions>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle</id>
+                        <goals><goal>bundle</goal></goals>
+                        <configuration>
+                            <instructions>
+                                <Bundle-Activator>org.apache.sling.javax.activation.internal.Activator</Bundle-Activator>
+                                <Export-Package>javax.activation;version=${javax.activation.version}</Export-Package>
+                                <Embed-Dependency>*;scope=compile</Embed-Dependency>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>nodepsbundle</id>
+                        <goals><goal>bundle</goal></goals>
+                        <configuration>
+                            <classifier>nodeps</classifier>
+                            <instructions>
+                                <Bundle-Name>
+                                    ${project.name} (No embedded dependencies)
+                                </Bundle-Name>
+                                <Bundle-Version>
+                                    ${project.version}-nodeps
+                                </Bundle-Version>
+                                <Bundle-Activator>org.apache.sling.javax.activation.internal.Activator</Bundle-Activator>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -77,6 +99,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
+            <version>4.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
-        <version>39</version>
+        <version>34</version>
         <relativePath/>
     </parent>
         
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.1</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>


### PR DESCRIPTION
An additional bundle with the classifier -nodeps is now generated which
does not contain the javax.activation classes/activation.jar file.
Also updated parent pom to latest version.